### PR TITLE
Proper name override

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -1,3 +1,0 @@
-paths:
-    src/pcl:
-        name: libpcl-all-dev

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,1 @@
+name: libpcl-all-dev


### PR DESCRIPTION
src/pcl is for when the meta file is at the root of the workspace

colcon.pkg is the right thing to stick in the package root