### PR TITLE
Adding colcon.pkg for building pcl-1.13

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,1 @@
+name: libpcl-all-dev


### PR DESCRIPTION
This change allows for colcon to build PCL 1.13 and provide libpcl-all-dev for packages that require it for dependencies. This change was tested on a feature branch originally, and now putting this in the master build. 