### PR TITLE
Suppress empty pointcloud warnings

### DIFF
--- a/common/include/pcl/conversions.h
+++ b/common/include/pcl/conversions.h
@@ -175,7 +175,7 @@ namespace pcl
     // check if there is data to copy
     if (msg.width * msg.height == 0)
     {
-      PCL_WARN("[pcl::fromPCLPointCloud2] No data to copy.\n");
+      PCL_INFO("[pcl::fromPCLPointCloud2] No data to copy.\n");
       return;
     }
 

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -596,7 +596,7 @@ namespace pcl
       assign(InputIterator first, InputIterator last, index_t new_width)
       {
         if (new_width == 0) {
-          PCL_WARN("Assignment with new_width equal to 0,"
+          PCL_INFO("Assignment with new_width equal to 0,"
                    "setting width to size of the cloud and height to 1\n");
           return assign(std::move(first), std::move(last));
         }
@@ -638,7 +638,7 @@ namespace pcl
       inline assign(std::initializer_list<PointT> ilist, index_t new_width)
       {
         if (new_width == 0) {
-          PCL_WARN("Assignment with new_width equal to 0,"
+          PCL_INFO("Assignment with new_width equal to 0,"
                    "setting width to size of the cloud and height to 1\n");
           return assign(std::move(ilist));
         }


### PR DESCRIPTION
Doesn't seem to be any way to do this dynamically